### PR TITLE
Fix keymap buffer and ignore help

### DIFF
--- a/lua/navigator/lspclient/clients.lua
+++ b/lua/navigator/lspclient/clients.lua
@@ -42,6 +42,7 @@ local disabled_ft = {
   'windline',
   'notify',
   'nofile',
+  'help',
   '',
 }
 -- local cap = vim.lsp.protocol.make_client_capabilities()

--- a/lua/navigator/lspclient/mapping.lua
+++ b/lua/navigator/lspclient/mapping.lua
@@ -216,6 +216,7 @@ local function set_mapping(lsp_attach_info)
       if value.desc then
         opts.desc = value.desc
       end
+      opts.buffer = bufnr
       vim.keymap.set(value.mode or 'n', value.key, value.func, opts)
       if string.find(value.desc, 'range format') and value.mode == 'v' then
         rfmtkey = value.key


### PR DESCRIPTION
the keymaps from navigator are applied to all buffers including help, maybe you didn't pay attention but this should be applied to the target attached buffer. Unless you have a reason to apply it everywhere ?